### PR TITLE
Add Malagassy compatiblity

### DIFF
--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -486,19 +486,23 @@ Phony.define do
   # Madagascar http://www.wtng.info/wtng-261-mg.html
   # http://www.itu.int/oth/T020200007F/en
   country '261',
-          none >> matched_split(
-              /\A200\d+\z/ => [2,3,3,3], # Telecom Malagasy (Telma)
-              /\A20\d+\z/ => [2,3,4], # Telecom Malagasy (Telma)
-              /\A23\d+\z/ => [2,3,4], # Digitel
-              /\A30\d+\z/ => [2,3,4], # mobile Madamobil (CDMA2000)
-              /\A31\d+\z/ => [2,3,4], # mobile Airtel Madagascar
-              /\A32\d+\z/ => [2,3,4], # mobile Orange Madagascar
-              /\A33\d+\z/ => [2,3,4], # mobile Airtel Madagascar
-              /\A34\d+\z/ => [2,3,4], # mobile Telecom Malagasy (Telma)
-              /\A5\d+\z/ => [3,3,3],  # pager
-              /\A22\d+\z/ => [3,3,3], # satellite GULFSAT Téléphonie
-              /\A6\d+\z/ => [3,3,3]   # satellite
-          )
+          # none >> matched_split(
+          #     /\A200\d+\z/ => [2,3,3,3], # Telecom Malagasy (Telma)
+          #     /\A20\d+\z/ => [2,3,4], # Telecom Malagasy (Telma)
+          #     /\A23\d+\z/ => [2,3,4], # Digitel
+          #     /\A30\d+\z/ => [2,3,4], # mobile Madamobil (CDMA2000)
+          #     /\A31\d+\z/ => [2,3,4], # mobile Airtel Madagascar
+          #     /\A32\d+\z/ => [2,3,4], # mobile Orange Madagascar
+          #     /\A33\d+\z/ => [2,3,4], # mobile Airtel Madagascar
+          #     /\A34\d+\z/ => [2,3,4], # mobile Telecom Malagasy (Telma)
+          #     /\A5\d+\z/ => [3,3,3],  # pager
+          #     /\A22\d+\z/ => [3,3,3], # satellite GULFSAT Téléphonie
+          #     /\A6\d+\z/ => [3,3,3]   # satellite
+          # ),
+          match(/\A(31)\d+\z/) >> split(3,4) | # mobile Airtel Madagascar
+          match(/\A(32)\d+\z/) >> split(3,4) | # mobile Orange Madagascar
+          match(/\A(33)\d+\z/) >> split(3,4) | # mobile Airtel Madagascar
+          match(/\A(34)\d+\z/) >> split(3,4)   # mobile Telecom Malagasy (Telma)
 
   country '262', # Reunion / Mayotte (new) http://www.wtng.info/wtng-262-fr.html
     trunk('0') |

--- a/lib/phony/countries.rb
+++ b/lib/phony/countries.rb
@@ -491,8 +491,9 @@ Phony.define do
               /\A20\d+\z/ => [2,3,4], # Telecom Malagasy (Telma)
               /\A23\d+\z/ => [2,3,4], # Digitel
               /\A30\d+\z/ => [2,3,4], # mobile Madamobil (CDMA2000)
-              /\A31\d+\z/ => [2,3,4], # mobile Sacel
+              /\A31\d+\z/ => [2,3,4], # mobile Airtel Madagascar
               /\A32\d+\z/ => [2,3,4], # mobile Orange Madagascar
+              /\A33\d+\z/ => [2,3,4], # mobile Airtel Madagascar
               /\A34\d+\z/ => [2,3,4], # mobile Telecom Malagasy (Telma)
               /\A5\d+\z/ => [3,3,3],  # pager
               /\A22\d+\z/ => [3,3,3], # satellite GULFSAT Téléphonie

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -187,10 +187,18 @@ describe 'plausibility' do
       it_is_correct_for 'Macedonia', :samples => ['+389 2 123 4567',
                                                    '+389 7 124 3456',
                                                    '+389 7 234 5678']
-      it_is_correct_for 'Madagascar', :samples => ['+261 20 012 345 678',
-                                                   '+261 20 124 3456',
-                                                   '+261 512 345 678',
-                                                   '+261 33 345 678']
+      it_is_correct_for 'Madagascar', :samples => ['+261 31 345 4678',
+                                                   '+261 32 345 4678',
+                                                   '+261 33 345 4678',
+                                                   '+261 34 345 4678']
+      it 'is incorrect for Madagascar' do
+        Phony.plausible?('+261 20 012 345 678').should be_falsey
+        Phony.plausible?('+261 20 124 3456').should be_falsey
+        Phony.plausible?('+261 512 345 678').should be_falsey
+        Phony.plausible?('+261 34 345 46789').should be_falsey
+        Phony.plausible?('+261 34 345 467').should be_falsey
+      end
+
       it_is_correct_for 'Malawi', :samples => ['+265 1725 123',
                                                '+265 213 456 789',
                                                '+265 9123 456',

--- a/spec/functional/plausibility_spec.rb
+++ b/spec/functional/plausibility_spec.rb
@@ -189,7 +189,8 @@ describe 'plausibility' do
                                                    '+389 7 234 5678']
       it_is_correct_for 'Madagascar', :samples => ['+261 20 012 345 678',
                                                    '+261 20 124 3456',
-                                                   '+261 512 345 678']
+                                                   '+261 512 345 678',
+                                                   '+261 33 345 678']
       it_is_correct_for 'Malawi', :samples => ['+265 1725 123',
                                                '+265 213 456 789',
                                                '+265 9123 456',

--- a/spec/lib/phony/countries_spec.rb
+++ b/spec/lib/phony/countries_spec.rb
@@ -990,9 +990,10 @@ describe 'country descriptions' do
       it_splits '218911234456', %w(218 91 1234 456)
     end
     describe 'Madagascar' do
-      it_splits '26120012345678', ['261', false, '20', '012', '345', '678']
-      it_splits '261201243456', ['261', false, *%w(20 124 3456)]
-      it_splits '261512345678', ['261', false, *%w(512 345 678)]
+      it_splits '261310254716', ['261', '31', *%w(025 4716)]
+      it_splits '261320254716', ['261', '32', *%w(025 4716)]
+      it_splits '261330254716', ['261', '33', *%w(025 4716)]
+      it_splits '261340254716', ['261', '34', *%w(025 4716)]
     end
     describe 'Malawi' do
       it_splits '2651725123', ['265', false, '1725', '123']


### PR DESCRIPTION
Covers:

- validation of Malagasy phone numbers (Airtel, Telma, Orange NDC + 5 other digits)
- return of NDC